### PR TITLE
Fix stubc return bytes

### DIFF
--- a/sqlite_wbtest.mbt
+++ b/sqlite_wbtest.mbt
@@ -53,7 +53,8 @@ test "sqlite_bind_text" {
   // Verify（sqlite_column_textを使用）
   let stmt2 = sqlite_prepare(db, cstring("SELECT name FROM t WHERE id = 1"))
   assert_eq(sqlite_step(stmt2), SQLITE_ROW)
-  let _ = sqlite_column_text(stmt2, 0) // Get as Bytes type
+  let got_column_text = sqlite_column_text(stmt2, 0)
+  assert_eq(@encoding/utf8.decode(got_column_text), "hello")
   sqlite_finalize(stmt2)
   sqlite_close(db)
 }
@@ -203,8 +204,9 @@ test "sqlite_bind_blob" {
   // Verify
   let stmt2 = sqlite_prepare(db, cstring("SELECT data FROM t WHERE id = 1"))
   assert_eq(sqlite_step(stmt2), SQLITE_ROW)
-  let _ = sqlite_column_blob(stmt2, 0)
+  let got_blob = sqlite_column_blob(stmt2, 0)
   assert_true(sqlite_column_bytes(stmt2, 0) > 0)
+  assert_eq(got_blob, blob_data)
   sqlite_finalize(stmt2)
   sqlite_close(db)
 }

--- a/stub.c
+++ b/stub.c
@@ -121,8 +121,12 @@ double sqlite_column_double(sqlite3_stmt* stmt, int32_t col) {
     return sqlite3_column_double(stmt, col);
 }
 
-const char* sqlite_column_text(sqlite3_stmt* stmt, int32_t col) {
-    return (const char*)sqlite3_column_text(stmt, col);
+moonbit_bytes_t sqlite_column_text(sqlite3_stmt* stmt, int32_t col) {
+    const char* text_str = (const char*)sqlite3_column_text(stmt, col);
+    int32_t text_str_len = strlen(text_str);
+    moonbit_bytes_t mb_bytes = moonbit_make_bytes(strlen(text_str), 0);
+    memcpy(mb_bytes, text_str, text_str_len);
+    return mb_bytes;
 }
 
 // ステートメントをリセット（再利用可能に）
@@ -158,8 +162,12 @@ int64_t sqlite_column_int64(sqlite3_stmt* stmt, int32_t col) {
     return sqlite3_column_int64(stmt, col);
 }
 
-const void* sqlite_column_blob(sqlite3_stmt* stmt, int32_t col) {
-    return sqlite3_column_blob(stmt, col);
+moonbit_bytes_t sqlite_column_blob(sqlite3_stmt* stmt, int32_t col) {
+    const void* blob = sqlite3_column_blob(stmt, col);
+    int32_t blob_len = sqlite3_column_bytes(stmt, col);
+    moonbit_bytes_t mb_bytes = moonbit_make_bytes(blob_len, 0);
+    memcpy(mb_bytes, blob, blob_len);
+    return mb_bytes;
 }
 
 int32_t sqlite_column_bytes(sqlite3_stmt* stmt, int32_t col) {


### PR DESCRIPTION
This pull request updates the way SQLite text and blob columns are handled in the C stub and corresponding tests. The main improvement is that both `sqlite_column_text` and `sqlite_column_blob` now return `moonbit_bytes_t` instead of raw pointers, ensuring safer and more consistent handling of binary/text data between C and MoonBit. The tests are also updated to verify the correctness of these changes.

### C API changes for SQLite column access

* Changed the return type of `sqlite_column_text` from `const char*` to `moonbit_bytes_t`, copying the text data into a MoonBit bytes object for safer interop. (`stub.c`)
* Changed the return type of `sqlite_column_blob` from `const void*` to `moonbit_bytes_t`, copying the blob data into a MoonBit bytes object. (`stub.c`)

### Test updates

* Updated the `sqlite_bind_text` test to decode the returned bytes and assert the result matches the expected string. (`sqlite_wbtest.mbt`)
* Updated the `sqlite_bind_blob` test to compare the returned blob bytes directly with the expected data. (`sqlite_wbtest.mbt`)