### PR TITLE
Change enum visibility to public for SqlValue

### DIFF
--- a/sqlite.mbt
+++ b/sqlite.mbt
@@ -462,7 +462,7 @@ pub fn Database::rollback_to(self : Database, name : String) -> Bool {
 // SqlValue enum for type-safe bind and column operations
 
 ///|
-pub enum SqlValue {
+pub(all) enum SqlValue {
   Null
   Int(Int)
   Int64(Int64)


### PR DESCRIPTION
This pull request makes a small change to the visibility of the `SqlValue` enum in the `sqlite.mbt` file, broadening its accessibility to all modules. This will allow other parts of the codebase to interact with `SqlValue` directly.

* Changed the visibility of the `SqlValue` enum from private to public for all modules (`pub(all)`) in `sqlite.mbt`.