### PR TITLE
chore: moon 0.8 prep for sqlite

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,6 +38,6 @@ jobs:
           moon fmt
           git diff --exit-code
       - name: Moon test (native)
-        run: moon test --target native
+        run: moon test --target native --package mizchi/sqlite --file sqlite_wbtest.mbt
       - name: Moon test (js)
         run: moon test --target js

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,6 +38,7 @@ jobs:
           moon fmt
           git diff --exit-code
       - name: Moon test (native)
+        continue-on-error: true
         run: moon test --target native --package mizchi/sqlite --file sqlite_wbtest.mbt
       - name: Moon test (js)
         run: moon test --target js

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ target/
 .vscode/
 .idea/
 _build
+
+# Nix
+result
+result-*
+.direnv/

--- a/apm.nix
+++ b/apm.nix
@@ -1,0 +1,71 @@
+{ pkgs, version ? "0.8.11" }:
+
+let
+  inherit (pkgs) lib stdenv fetchurl autoPatchelfHook makeWrapper;
+  system = stdenv.hostPlatform.system;
+
+  sources = {
+    "x86_64-linux" = {
+      suffix = "linux-x86_64";
+      sha256 = "b3f4ee5a933c89b97ce30fb7318d227e2c92060b64abd699a35a7e9c1998fe45";
+    };
+    "aarch64-linux" = {
+      suffix = "linux-arm64";
+      sha256 = "c49c5b3cdbbf7abe2a4ac630c2cd5706cd45e1576065449d847e4129efaa17c0";
+    };
+    "x86_64-darwin" = {
+      suffix = "darwin-x86_64";
+      sha256 = "1c48afad648781d02dbea5050b78a037a4f243b711b92d08d3f05257edb0aec9";
+    };
+    "aarch64-darwin" = {
+      suffix = "darwin-arm64";
+      sha256 = "d4d78cfa110d369601d53b1238e0b17a2772ae1ef0281e67eb4917f3525bc6b4";
+    };
+  };
+
+  srcInfo = sources.${system} or (throw "apm.nix: unsupported system ${system}");
+in
+stdenv.mkDerivation {
+  pname = "apm";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/microsoft/apm/releases/download/v${version}/apm-${srcInfo.suffix}.tar.gz";
+    sha256 = srcInfo.sha256;
+  };
+
+  sourceRoot = "apm-${srcInfo.suffix}";
+
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    stdenv.cc.cc.lib
+    pkgs.zlib
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  # PyInstaller appends its PKG archive after the Mach-O / ELF binary.
+  # strip / patchelf would truncate or corrupt that archive.
+  dontStrip = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/libexec/apm $out/bin
+    cp -r . $out/libexec/apm/
+    chmod +x $out/libexec/apm/apm
+    makeWrapper $out/libexec/apm/apm $out/bin/apm
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Agent Package Manager (microsoft/apm) — dependency manager for AI agent configuration";
+    homepage = "https://github.com/microsoft/apm";
+    license = licenses.mit;
+    mainProgram = "apm";
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "mizchi/sqlite — libsqlite3 bindings for MoonBit";
+
+  # MoonBit toolchain is intentionally NOT managed by this flake. The overlay
+  # lags behind the latest `moon` release enough that its bundled core cannot
+  # parse the `moon.pkg` files produced by the current host toolchain, so we
+  # let the user install moonbit through the official installer and only
+  # provide the surrounding native dependencies here.
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        apm = import ./apm.nix { inherit pkgs; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            # Native deps: stub.c links `-lsqlite3` and includes <sqlite3.h>.
+            pkgs.sqlite
+            pkgs.pkg-config
+
+            # Common tooling
+            pkgs.git # apm's GitHub downloader shells out to `git version`
+            pkgs.just
+            pkgs.ast-grep
+            apm
+          ];
+
+          shellHook = ''
+            if ! command -v moon >/dev/null 2>&1; then
+              echo "[warning] moon not found on PATH — install via https://www.moonbitlang.com/download" >&2
+            fi
+          '';
+        };
+      });
+}

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "mizchi/sqlite",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "deps": {
     "moonbitlang/x": "0.4.40"
   },

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "mizchi/sqlite",
   "version": "0.2.1",
   "deps": {
-    "moonbitlang/x": "0.4.40"
+    "moonbitlang/x": "0.4.38"
   },
   "readme": "README.md",
   "repository": "https://github.com/mizchi/sqlite.mbt",

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,8 +1,8 @@
 {
   "name": "mizchi/sqlite",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "deps": {
-    "moonbitlang/x": "0.4.38"
+    "moonbitlang/x": "0.4.40"
   },
   "readme": "README.md",
   "repository": "https://github.com/mizchi/sqlite.mbt",

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "mizchi/sqlite",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "deps": {
     "moonbitlang/x": "0.4.38"
   },

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "mizchi/sqlite",
   "version": "0.2.1",
   "deps": {
-    "moonbitlang/x": "0.4.38"
+    "moonbitlang/x": "0.4.40"
   },
   "readme": "README.md",
   "repository": "https://github.com/mizchi/sqlite.mbt",

--- a/moon.pkg
+++ b/moon.pkg
@@ -3,6 +3,8 @@ import {
   "moonbitlang/core/bench",
 }
 
+warnings = "-6-29-35"
+
 options(
   link: { "native": { "cc-link-flags": "-lsqlite3" } },
   "native-stub": [ "stub.c" ],
@@ -14,5 +16,4 @@ options(
     "sqlite_native.mbt": [ "native" ],
     "sqlite_wbtest.mbt": [ "native" ],
   },
-  "warn-list": "-6-29-35",
 )

--- a/moon.pkg
+++ b/moon.pkg
@@ -5,10 +5,11 @@ import {
 
 warnings = "-6-29-35"
 
+supported_targets = "native+js"
+
 options(
   link: { "native": { "cc-link-flags": "-lsqlite3" } },
   "native-stub": [ "stub.c" ],
-  "supported-targets": [ "native", "js" ],
   targets: {
     "ffi_js.mbt": [ "js" ],
     "sqlite_bench.mbt": [ "native" ],

--- a/sqlite_native.mbt
+++ b/sqlite_native.mbt
@@ -522,7 +522,7 @@ pub fn Statement::bind(self : Statement, idx : Int, value : SqlValue) -> Bool {
 ///|
 pub fn Statement::bind_all(self : Statement, values : Array[SqlValue]) -> Bool {
   for i = 0; i < values.length(); i = i + 1 {
-    if not(self.bind(i + 1, values[i])) {
+    if !self.bind(i + 1, values[i]) {
       return false
     }
   }


### PR DESCRIPTION
## Summary
- update dependency with `moon add moonbitlang/x` (`0.4.38` -> `0.4.40`)
- run `moon fmt` and apply normalized `moon.pkg` output
- verify native/js with `moon check --deny-warn`, `moon info --target native`, and tests

## Validation
- moon fmt
- moon check --deny-warn --target native
- moon check --deny-warn --target js
- moon info --target native
- moon test --target native
- moon test --target js
