### PR TITLE
fix: Prevent SIGSEGV on Linux

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,4 @@ BreakBeforeBraces: Attach
 IndentWidth: 4
 ColumnLimit: 0
 AllowShortIfStatementsOnASingleLine: WithoutElse
+PointerAlignment: Left

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: LLVM
+BreakBeforeBraces: Attach
+IndentWidth: 4
+ColumnLimit: 0
+AllowShortIfStatementsOnASingleLine: WithoutElse

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "mizchi/sqlite",
   "version": "0.2.1",
   "deps": {
-    "moonbitlang/x": "0.4.38"
+    "moonbitlang/x": "0.4.40"
   },
   "readme": "README.md",
   "repository": "https://github.com/mizchi/sqlite.mbt",

--- a/moon.pkg
+++ b/moon.pkg
@@ -3,6 +3,8 @@ import {
   "moonbitlang/core/bench",
 }
 
+warnings = "-6-29-35"
+
 options(
   link: { "native": { "cc-link-flags": "-lsqlite3" } },
   "native-stub": [ "stub.c" ],
@@ -14,5 +16,4 @@ options(
     "sqlite_native.mbt": [ "native" ],
     "sqlite_wbtest.mbt": [ "native" ],
   },
-  "warn-list": "-6-29-35",
 )

--- a/stub.c
+++ b/stub.c
@@ -4,48 +4,48 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void noop_finalizer(void *self) {}
+static void noop_finalizer(void* self) {}
 
 // Helper functions to wrap raw sqlite3* and sqlite3_stmt* pointers in MoonBit external objects
 
-static void *wrap_db(sqlite3 *db) {
+static void* wrap_db(sqlite3* db) {
     if (!db) return NULL;
-    void *obj = moonbit_make_external_object(noop_finalizer, sizeof(sqlite3 *));
-    *(sqlite3 **)obj = db;
+    void* obj = moonbit_make_external_object(noop_finalizer, sizeof(sqlite3*));
+    *(sqlite3**)obj = db;
     return obj;
 }
 
-static void *wrap_stmt(sqlite3_stmt *stmt) {
+static void* wrap_stmt(sqlite3_stmt* stmt) {
     if (!stmt) return NULL;
-    void *obj = moonbit_make_external_object(noop_finalizer, sizeof(sqlite3_stmt *));
-    *(sqlite3_stmt **)obj = stmt;
+    void* obj = moonbit_make_external_object(noop_finalizer, sizeof(sqlite3_stmt*));
+    *(sqlite3_stmt**)obj = stmt;
     return obj;
 }
 
-static inline sqlite3 *get_db(void *obj) {
+static inline sqlite3* get_db(void* obj) {
     if (!obj) return NULL;
-    return *(sqlite3 **)obj;
+    return *(sqlite3**)obj;
 }
 
-static inline sqlite3_stmt *get_stmt(void *obj) {
+static inline sqlite3_stmt* get_stmt(void* obj) {
     if (!obj) return NULL;
-    return *(sqlite3_stmt **)obj;
+    return *(sqlite3_stmt**)obj;
 }
 
 // Helper to convert MoonBit Bytes to C string
 // @encoding.encode_utf8() returns UTF-8 encoded bytes, so we copy directly and add NULL terminator
-static char *bytes_to_cstring(moonbit_bytes_t bytes) {
+static char* bytes_to_cstring(moonbit_bytes_t bytes) {
     int32_t len = Moonbit_array_length(bytes);
-    char *str = (char *)malloc(len + 1);
+    char* str = (char*)malloc(len + 1);
     memcpy(str, bytes, len);
     str[len] = '\0';
     return str;
 }
 
 // Open database (returns db on success, NULL on failure)
-void *sqlite_open(moonbit_bytes_t filename) {
-    char *fname = bytes_to_cstring(filename);
-    sqlite3 *db;
+void* sqlite_open(moonbit_bytes_t filename) {
+    char* fname = bytes_to_cstring(filename);
+    sqlite3* db;
     int rc = sqlite3_open(fname, &db);
     free(fname);
     if (rc != SQLITE_OK) {
@@ -56,14 +56,14 @@ void *sqlite_open(moonbit_bytes_t filename) {
 }
 
 // Open database with extended options
-void *sqlite_open_v2(moonbit_bytes_t filename, int32_t flags, moonbit_bytes_t vfs) {
-    char *fname = bytes_to_cstring(filename);
-    char *vfs_str = NULL;
+void* sqlite_open_v2(moonbit_bytes_t filename, int32_t flags, moonbit_bytes_t vfs) {
+    char* fname = bytes_to_cstring(filename);
+    char* vfs_str = NULL;
     if (Moonbit_array_length(vfs) > 0) {
         vfs_str = bytes_to_cstring(vfs);
     }
 
-    sqlite3 *db;
+    sqlite3* db;
     int rc = sqlite3_open_v2(fname, &db, flags, vfs_str);
 
     free(fname);
@@ -77,21 +77,21 @@ void *sqlite_open_v2(moonbit_bytes_t filename, int32_t flags, moonbit_bytes_t vf
 }
 
 // Check if pointer is NULL
-int32_t sqlite_is_null(void *ptr) {
+int32_t sqlite_is_null(void* ptr) {
     return ptr == NULL ? 1 : 0;
 }
 
-int32_t sqlite_stmt_is_null(void *ptr) {
+int32_t sqlite_stmt_is_null(void* ptr) {
     return ptr == NULL ? 1 : 0;
 }
 
 // Close database
-void sqlite_close(void *obj) { sqlite3_close(get_db(obj)); }
+void sqlite_close(void* obj) { sqlite3_close(get_db(obj)); }
 
 // Execute SQL (no result). Returns 0 on success
-int32_t sqlite_exec(void *obj, moonbit_bytes_t sql) {
-    char *sql_str = bytes_to_cstring(sql);
-    char *err_msg = NULL;
+int32_t sqlite_exec(void* obj, moonbit_bytes_t sql) {
+    char* sql_str = bytes_to_cstring(sql);
+    char* err_msg = NULL;
     int rc = sqlite3_exec(get_db(obj), sql_str, NULL, NULL, &err_msg);
     free(sql_str);
     if (err_msg) {
@@ -101,9 +101,9 @@ int32_t sqlite_exec(void *obj, moonbit_bytes_t sql) {
 }
 
 // Create prepared statement (returns NULL on failure)
-void *sqlite_prepare(void *obj, moonbit_bytes_t sql) {
-    char *sql_str = bytes_to_cstring(sql);
-    sqlite3_stmt *stmt = NULL;
+void* sqlite_prepare(void* obj, moonbit_bytes_t sql) {
+    char* sql_str = bytes_to_cstring(sql);
+    sqlite3_stmt* stmt = NULL;
     int rc = sqlite3_prepare_v2(get_db(obj), sql_str, -1, &stmt, NULL);
     free(sql_str);
     if (rc != SQLITE_OK) {
@@ -113,41 +113,41 @@ void *sqlite_prepare(void *obj, moonbit_bytes_t sql) {
 }
 
 // Finalize statement
-void sqlite_finalize(void *obj) { sqlite3_finalize(get_stmt(obj)); }
+void sqlite_finalize(void* obj) { sqlite3_finalize(get_stmt(obj)); }
 
 // Bind parameter (1-indexed)
-int32_t sqlite_bind_int(void *obj, int32_t idx, int32_t value) {
+int32_t sqlite_bind_int(void* obj, int32_t idx, int32_t value) {
     return sqlite3_bind_int(get_stmt(obj), idx, value);
 }
 
-int32_t sqlite_bind_double(void *obj, int32_t idx, double value) {
+int32_t sqlite_bind_double(void* obj, int32_t idx, double value) {
     return sqlite3_bind_double(get_stmt(obj), idx, value);
 }
 
-int32_t sqlite_bind_text(void *obj, int32_t idx, moonbit_bytes_t text) {
-    char *text_str = bytes_to_cstring(text);
+int32_t sqlite_bind_text(void* obj, int32_t idx, moonbit_bytes_t text) {
+    char* text_str = bytes_to_cstring(text);
     int rc = sqlite3_bind_text(get_stmt(obj), idx, text_str, -1, SQLITE_TRANSIENT);
     free(text_str);
     return rc;
 }
 
 // Step to next row. 100=SQLITE_ROW (has data), 101=SQLITE_DONE (finished)
-int32_t sqlite_step(void *obj) { return sqlite3_step(get_stmt(obj)); }
+int32_t sqlite_step(void* obj) { return sqlite3_step(get_stmt(obj)); }
 
 // Get column value (0-indexed)
-int32_t sqlite_column_int(void *obj, int32_t col) {
+int32_t sqlite_column_int(void* obj, int32_t col) {
     return sqlite3_column_int(get_stmt(obj), col);
 }
 
-double sqlite_column_double(void *obj, int32_t col) {
+double sqlite_column_double(void* obj, int32_t col) {
     return sqlite3_column_double(get_stmt(obj), col);
 }
 
 // Return SQLite text column as MoonBit Bytes
 // moonbit_bytes_t is a length-prefixed byte array
-moonbit_bytes_t sqlite_column_text(void *obj, int32_t col) {
-    sqlite3_stmt *stmt = get_stmt(obj);
-    const unsigned char *text = sqlite3_column_text(stmt, col);
+moonbit_bytes_t sqlite_column_text(void* obj, int32_t col) {
+    sqlite3_stmt* stmt = get_stmt(obj);
+    const unsigned char* text = sqlite3_column_text(stmt, col);
     int len = sqlite3_column_bytes(stmt, col);
     if (text == NULL || len == 0) {
         return moonbit_make_bytes(0, 0);
@@ -158,39 +158,39 @@ moonbit_bytes_t sqlite_column_text(void *obj, int32_t col) {
 }
 
 // Reset statement (make it reusable)
-void sqlite_reset(void *obj) { sqlite3_reset(get_stmt(obj)); }
+void sqlite_reset(void* obj) { sqlite3_reset(get_stmt(obj)); }
 
 // Error handling
-int32_t sqlite_errcode(void *obj) { return sqlite3_errcode(get_db(obj)); }
+int32_t sqlite_errcode(void* obj) { return sqlite3_errcode(get_db(obj)); }
 
-const char *sqlite_errmsg(void *obj) { return sqlite3_errmsg(get_db(obj)); }
+const char* sqlite_errmsg(void* obj) { return sqlite3_errmsg(get_db(obj)); }
 
 // Additional bind functions
-int32_t sqlite_bind_null(void *obj, int32_t idx) {
+int32_t sqlite_bind_null(void* obj, int32_t idx) {
     return sqlite3_bind_null(get_stmt(obj), idx);
 }
 
 // Note: Using int64_t for idx to avoid ABI issues with mixed 32/64-bit parameters
 // on some platforms (Linux x86-64). MoonBit may pass parameters differently
 // when mixing Int and Int64 types.
-int32_t sqlite_bind_int64(void *obj, int64_t idx, int64_t value) {
+int32_t sqlite_bind_int64(void* obj, int64_t idx, int64_t value) {
     return sqlite3_bind_int64(get_stmt(obj), (int)idx, value);
 }
 
-int32_t sqlite_bind_blob(void *obj, int32_t idx, moonbit_bytes_t blob) {
+int32_t sqlite_bind_blob(void* obj, int32_t idx, moonbit_bytes_t blob) {
     int32_t len = Moonbit_array_length(blob);
     return sqlite3_bind_blob(get_stmt(obj), idx, blob, len, SQLITE_TRANSIENT);
 }
 
 // Additional column getter functions
-int64_t sqlite_column_int64(void *obj, int32_t col) {
+int64_t sqlite_column_int64(void* obj, int32_t col) {
     return sqlite3_column_int64(get_stmt(obj), col);
 }
 
 // Return SQLite BLOB column as MoonBit Bytes
-moonbit_bytes_t sqlite_column_blob(void *obj, int32_t col) {
-    sqlite3_stmt *stmt = get_stmt(obj);
-    const void *blob = sqlite3_column_blob(stmt, col);
+moonbit_bytes_t sqlite_column_blob(void* obj, int32_t col) {
+    sqlite3_stmt* stmt = get_stmt(obj);
+    const void* blob = sqlite3_column_blob(stmt, col);
     int len = sqlite3_column_bytes(stmt, col);
     if (blob == NULL || len == 0) {
         return moonbit_make_bytes(0, 0);
@@ -200,64 +200,64 @@ moonbit_bytes_t sqlite_column_blob(void *obj, int32_t col) {
     return result;
 }
 
-int32_t sqlite_column_bytes(void *obj, int32_t col) {
+int32_t sqlite_column_bytes(void* obj, int32_t col) {
     return sqlite3_column_bytes(get_stmt(obj), col);
 }
 
-int32_t sqlite_column_type(void *obj, int32_t col) {
+int32_t sqlite_column_type(void* obj, int32_t col) {
     return sqlite3_column_type(get_stmt(obj), col);
 }
 
 // Metadata functions
-int32_t sqlite_column_count(void *obj) {
+int32_t sqlite_column_count(void* obj) {
     return sqlite3_column_count(get_stmt(obj));
 }
 
-const char *sqlite_column_name(void *obj, int32_t col) {
+const char* sqlite_column_name(void* obj, int32_t col) {
     return sqlite3_column_name(get_stmt(obj), col);
 }
 
-int32_t sqlite_changes(void *obj) { return sqlite3_changes(get_db(obj)); }
+int32_t sqlite_changes(void* obj) { return sqlite3_changes(get_db(obj)); }
 
-int64_t sqlite_last_insert_rowid(void *obj) {
+int64_t sqlite_last_insert_rowid(void* obj) {
     return sqlite3_last_insert_rowid(get_db(obj));
 }
 
 // Clear statement bindings
-int32_t sqlite_clear_bindings(void *obj) {
+int32_t sqlite_clear_bindings(void* obj) {
     return sqlite3_clear_bindings(get_stmt(obj));
 }
 
 // Concurrency control
-int32_t sqlite_busy_timeout(void *obj, int32_t ms) {
+int32_t sqlite_busy_timeout(void* obj, int32_t ms) {
     return sqlite3_busy_timeout(get_db(obj), ms);
 }
 
 // Transaction management
-int32_t sqlite_get_autocommit(void *obj) {
+int32_t sqlite_get_autocommit(void* obj) {
     return sqlite3_get_autocommit(get_db(obj));
 }
 
-int32_t sqlite_total_changes(void *obj) {
+int32_t sqlite_total_changes(void* obj) {
     return sqlite3_total_changes(get_db(obj));
 }
 
 // Statement introspection
-const char *sqlite_sql(void *obj) {
-    const char *sql = sqlite3_sql(get_stmt(obj));
+const char* sqlite_sql(void* obj) {
+    const char* sql = sqlite3_sql(get_stmt(obj));
     return sql ? sql : "";
 }
 
-int32_t sqlite_bind_parameter_count(void *obj) {
+int32_t sqlite_bind_parameter_count(void* obj) {
     return sqlite3_bind_parameter_count(get_stmt(obj));
 }
 
-int32_t sqlite_stmt_readonly(void *obj) {
+int32_t sqlite_stmt_readonly(void* obj) {
     return sqlite3_stmt_readonly(get_stmt(obj));
 }
 
 // Extended error handling
-int32_t sqlite_extended_errcode(void *obj) {
+int32_t sqlite_extended_errcode(void* obj) {
     return sqlite3_extended_errcode(get_db(obj));
 }
 
@@ -265,8 +265,8 @@ int32_t sqlite_extended_errcode(void *obj) {
 // Note: sqlite3_errstr returns static string, so we copy it
 static char errstr_buffer[256];
 
-const char *sqlite_errstr(int32_t errcode) {
-    const char *msg = sqlite3_errstr(errcode);
+const char* sqlite_errstr(int32_t errcode) {
+    const char* msg = sqlite3_errstr(errcode);
     if (msg) {
         strncpy(errstr_buffer, msg, sizeof(errstr_buffer) - 1);
         errstr_buffer[sizeof(errstr_buffer) - 1] = '\0';
@@ -278,8 +278,8 @@ const char *sqlite_errstr(int32_t errcode) {
 // Get parameter name (copy static string to buffer)
 static char param_name_buffer[256];
 
-const char *sqlite_bind_parameter_name(void *obj, int32_t idx) {
-    const char *name = sqlite3_bind_parameter_name(get_stmt(obj), idx);
+const char* sqlite_bind_parameter_name(void* obj, int32_t idx) {
+    const char* name = sqlite3_bind_parameter_name(get_stmt(obj), idx);
     if (name) {
         strncpy(param_name_buffer, name, sizeof(param_name_buffer) - 1);
         param_name_buffer[sizeof(param_name_buffer) - 1] = '\0';
@@ -288,8 +288,8 @@ const char *sqlite_bind_parameter_name(void *obj, int32_t idx) {
     return "";
 }
 
-int32_t sqlite_bind_parameter_index(void *obj, moonbit_bytes_t name) {
-    char *name_str = bytes_to_cstring(name);
+int32_t sqlite_bind_parameter_index(void* obj, moonbit_bytes_t name) {
+    char* name_str = bytes_to_cstring(name);
     int idx = sqlite3_bind_parameter_index(get_stmt(obj), name_str);
     free(name_str);
     return idx;
@@ -298,9 +298,9 @@ int32_t sqlite_bind_parameter_index(void *obj, moonbit_bytes_t name) {
 // Get database filename (copy static string to buffer)
 static char db_filename_buffer[512];
 
-const char *sqlite_db_filename(void *obj, moonbit_bytes_t dbname) {
-    char *dbname_str = bytes_to_cstring(dbname);
-    const char *filename = sqlite3_db_filename(get_db(obj), dbname_str);
+const char* sqlite_db_filename(void* obj, moonbit_bytes_t dbname) {
+    char* dbname_str = bytes_to_cstring(dbname);
+    const char* filename = sqlite3_db_filename(get_db(obj), dbname_str);
     free(dbname_str);
 
     if (filename) {
@@ -311,8 +311,8 @@ const char *sqlite_db_filename(void *obj, moonbit_bytes_t dbname) {
     return "";
 }
 
-int32_t sqlite_db_readonly(void *obj, moonbit_bytes_t dbname) {
-    char *dbname_str = bytes_to_cstring(dbname);
+int32_t sqlite_db_readonly(void* obj, moonbit_bytes_t dbname) {
+    char* dbname_str = bytes_to_cstring(dbname);
     int readonly = sqlite3_db_readonly(get_db(obj), dbname_str);
     free(dbname_str);
     return readonly;
@@ -321,8 +321,8 @@ int32_t sqlite_db_readonly(void *obj, moonbit_bytes_t dbname) {
 // Get expanded SQL (dynamically allocated string)
 static char expanded_sql_buffer[1024];
 
-const char *sqlite_expanded_sql(void *obj) {
-    char *sql = sqlite3_expanded_sql(get_stmt(obj));
+const char* sqlite_expanded_sql(void* obj) {
+    char* sql = sqlite3_expanded_sql(get_stmt(obj));
     if (sql) {
         strncpy(expanded_sql_buffer, sql, sizeof(expanded_sql_buffer) - 1);
         expanded_sql_buffer[sizeof(expanded_sql_buffer) - 1] = '\0';
@@ -333,11 +333,11 @@ const char *sqlite_expanded_sql(void *obj) {
 }
 
 // Interrupt running query
-void sqlite_interrupt(void *obj) {
+void sqlite_interrupt(void* obj) {
     sqlite3_interrupt(get_db(obj));
 }
 
 // Set/get resource limits
-int32_t sqlite_limit(void *obj, int32_t id, int32_t newVal) {
+int32_t sqlite_limit(void* obj, int32_t id, int32_t newVal) {
     return sqlite3_limit(get_db(obj), id, newVal);
 }

--- a/stub.c
+++ b/stub.c
@@ -1,41 +1,69 @@
-#include <sqlite3.h>
 #include <moonbit.h>
+#include <sqlite3.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
+
+static void noop_finalizer(void *self) {}
+
+// Helper functions to wrap raw sqlite3* and sqlite3_stmt* pointers in MoonBit external objects
+
+static void *wrap_db(sqlite3 *db) {
+    if (!db) return NULL;
+    void *obj = moonbit_make_external_object(noop_finalizer, sizeof(sqlite3 *));
+    *(sqlite3 **)obj = db;
+    return obj;
+}
+
+static void *wrap_stmt(sqlite3_stmt *stmt) {
+    if (!stmt) return NULL;
+    void *obj = moonbit_make_external_object(noop_finalizer, sizeof(sqlite3_stmt *));
+    *(sqlite3_stmt **)obj = stmt;
+    return obj;
+}
+
+static inline sqlite3 *get_db(void *obj) {
+    if (!obj) return NULL;
+    return *(sqlite3 **)obj;
+}
+
+static inline sqlite3_stmt *get_stmt(void *obj) {
+    if (!obj) return NULL;
+    return *(sqlite3_stmt **)obj;
+}
 
 // Helper to convert MoonBit Bytes to C string
 // @encoding.encode_utf8() returns UTF-8 encoded bytes, so we copy directly and add NULL terminator
-static char* bytes_to_cstring(moonbit_bytes_t bytes) {
+static char *bytes_to_cstring(moonbit_bytes_t bytes) {
     int32_t len = Moonbit_array_length(bytes);
-    char* str = (char*)malloc(len + 1);
+    char *str = (char *)malloc(len + 1);
     memcpy(str, bytes, len);
     str[len] = '\0';
     return str;
 }
 
 // Open database (returns db on success, NULL on failure)
-sqlite3* sqlite_open(moonbit_bytes_t filename) {
-    char* fname = bytes_to_cstring(filename);
-    sqlite3* db;
+void *sqlite_open(moonbit_bytes_t filename) {
+    char *fname = bytes_to_cstring(filename);
+    sqlite3 *db;
     int rc = sqlite3_open(fname, &db);
     free(fname);
     if (rc != SQLITE_OK) {
         sqlite3_close(db);
         return NULL;
     }
-    return db;
+    return wrap_db(db);
 }
 
 // Open database with extended options
-sqlite3* sqlite_open_v2(moonbit_bytes_t filename, int32_t flags, moonbit_bytes_t vfs) {
-    char* fname = bytes_to_cstring(filename);
-    char* vfs_str = NULL;
+void *sqlite_open_v2(moonbit_bytes_t filename, int32_t flags, moonbit_bytes_t vfs) {
+    char *fname = bytes_to_cstring(filename);
+    char *vfs_str = NULL;
     if (Moonbit_array_length(vfs) > 0) {
         vfs_str = bytes_to_cstring(vfs);
     }
 
-    sqlite3* db;
+    sqlite3 *db;
     int rc = sqlite3_open_v2(fname, &db, flags, vfs_str);
 
     free(fname);
@@ -45,28 +73,26 @@ sqlite3* sqlite_open_v2(moonbit_bytes_t filename, int32_t flags, moonbit_bytes_t
         sqlite3_close(db);
         return NULL;
     }
-    return db;
+    return wrap_db(db);
 }
 
 // Check if pointer is NULL
-int32_t sqlite_is_null(void* ptr) {
+int32_t sqlite_is_null(void *ptr) {
     return ptr == NULL ? 1 : 0;
 }
 
-int32_t sqlite_stmt_is_null(sqlite3_stmt* ptr) {
+int32_t sqlite_stmt_is_null(void *ptr) {
     return ptr == NULL ? 1 : 0;
 }
 
 // Close database
-void sqlite_close(sqlite3* db) {
-    sqlite3_close(db);
-}
+void sqlite_close(void *obj) { sqlite3_close(get_db(obj)); }
 
 // Execute SQL (no result). Returns 0 on success
-int32_t sqlite_exec(sqlite3* db, moonbit_bytes_t sql) {
-    char* sql_str = bytes_to_cstring(sql);
-    char* err_msg = NULL;
-    int rc = sqlite3_exec(db, sql_str, NULL, NULL, &err_msg);
+int32_t sqlite_exec(void *obj, moonbit_bytes_t sql) {
+    char *sql_str = bytes_to_cstring(sql);
+    char *err_msg = NULL;
+    int rc = sqlite3_exec(get_db(obj), sql_str, NULL, NULL, &err_msg);
     free(sql_str);
     if (err_msg) {
         sqlite3_free(err_msg);
@@ -75,56 +101,53 @@ int32_t sqlite_exec(sqlite3* db, moonbit_bytes_t sql) {
 }
 
 // Create prepared statement (returns NULL on failure)
-sqlite3_stmt* sqlite_prepare(sqlite3* db, moonbit_bytes_t sql) {
-    char* sql_str = bytes_to_cstring(sql);
-    sqlite3_stmt* stmt = NULL;
-    int rc = sqlite3_prepare_v2(db, sql_str, -1, &stmt, NULL);
+void *sqlite_prepare(void *obj, moonbit_bytes_t sql) {
+    char *sql_str = bytes_to_cstring(sql);
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(get_db(obj), sql_str, -1, &stmt, NULL);
     free(sql_str);
     if (rc != SQLITE_OK) {
         return NULL;
     }
-    return stmt;
+    return wrap_stmt(stmt);
 }
 
 // Finalize statement
-void sqlite_finalize(sqlite3_stmt* stmt) {
-    sqlite3_finalize(stmt);
-}
+void sqlite_finalize(void *obj) { sqlite3_finalize(get_stmt(obj)); }
 
 // Bind parameter (1-indexed)
-int32_t sqlite_bind_int(sqlite3_stmt* stmt, int32_t idx, int32_t value) {
-    return sqlite3_bind_int(stmt, idx, value);
+int32_t sqlite_bind_int(void *obj, int32_t idx, int32_t value) {
+    return sqlite3_bind_int(get_stmt(obj), idx, value);
 }
 
-int32_t sqlite_bind_double(sqlite3_stmt* stmt, int32_t idx, double value) {
-    return sqlite3_bind_double(stmt, idx, value);
+int32_t sqlite_bind_double(void *obj, int32_t idx, double value) {
+    return sqlite3_bind_double(get_stmt(obj), idx, value);
 }
 
-int32_t sqlite_bind_text(sqlite3_stmt* stmt, int32_t idx, moonbit_bytes_t text) {
-    char* text_str = bytes_to_cstring(text);
-    int rc = sqlite3_bind_text(stmt, idx, text_str, -1, SQLITE_TRANSIENT);
+int32_t sqlite_bind_text(void *obj, int32_t idx, moonbit_bytes_t text) {
+    char *text_str = bytes_to_cstring(text);
+    int rc = sqlite3_bind_text(get_stmt(obj), idx, text_str, -1, SQLITE_TRANSIENT);
     free(text_str);
     return rc;
 }
 
 // Step to next row. 100=SQLITE_ROW (has data), 101=SQLITE_DONE (finished)
-int32_t sqlite_step(sqlite3_stmt* stmt) {
-    return sqlite3_step(stmt);
-}
+int32_t sqlite_step(void *obj) { return sqlite3_step(get_stmt(obj)); }
 
 // Get column value (0-indexed)
-int32_t sqlite_column_int(sqlite3_stmt* stmt, int32_t col) {
-    return sqlite3_column_int(stmt, col);
+int32_t sqlite_column_int(void *obj, int32_t col) {
+    return sqlite3_column_int(get_stmt(obj), col);
 }
 
-double sqlite_column_double(sqlite3_stmt* stmt, int32_t col) {
-    return sqlite3_column_double(stmt, col);
+double sqlite_column_double(void *obj, int32_t col) {
+    return sqlite3_column_double(get_stmt(obj), col);
 }
 
 // Return SQLite text column as MoonBit Bytes
 // moonbit_bytes_t is a length-prefixed byte array
-moonbit_bytes_t sqlite_column_text(sqlite3_stmt* stmt, int32_t col) {
-    const unsigned char* text = sqlite3_column_text(stmt, col);
+moonbit_bytes_t sqlite_column_text(void *obj, int32_t col) {
+    sqlite3_stmt *stmt = get_stmt(obj);
+    const unsigned char *text = sqlite3_column_text(stmt, col);
     int len = sqlite3_column_bytes(stmt, col);
     if (text == NULL || len == 0) {
         return moonbit_make_bytes(0, 0);
@@ -135,44 +158,39 @@ moonbit_bytes_t sqlite_column_text(sqlite3_stmt* stmt, int32_t col) {
 }
 
 // Reset statement (make it reusable)
-void sqlite_reset(sqlite3_stmt* stmt) {
-    sqlite3_reset(stmt);
-}
+void sqlite_reset(void *obj) { sqlite3_reset(get_stmt(obj)); }
 
 // Error handling
-int32_t sqlite_errcode(sqlite3* db) {
-    return sqlite3_errcode(db);
-}
+int32_t sqlite_errcode(void *obj) { return sqlite3_errcode(get_db(obj)); }
 
-const char* sqlite_errmsg(sqlite3* db) {
-    return sqlite3_errmsg(db);
-}
+const char *sqlite_errmsg(void *obj) { return sqlite3_errmsg(get_db(obj)); }
 
 // Additional bind functions
-int32_t sqlite_bind_null(sqlite3_stmt* stmt, int32_t idx) {
-    return sqlite3_bind_null(stmt, idx);
+int32_t sqlite_bind_null(void *obj, int32_t idx) {
+    return sqlite3_bind_null(get_stmt(obj), idx);
 }
 
 // Note: Using int64_t for idx to avoid ABI issues with mixed 32/64-bit parameters
 // on some platforms (Linux x86-64). MoonBit may pass parameters differently
 // when mixing Int and Int64 types.
-int32_t sqlite_bind_int64(sqlite3_stmt* stmt, int64_t idx, int64_t value) {
-    return sqlite3_bind_int64(stmt, (int)idx, value);
+int32_t sqlite_bind_int64(void *obj, int64_t idx, int64_t value) {
+    return sqlite3_bind_int64(get_stmt(obj), (int)idx, value);
 }
 
-int32_t sqlite_bind_blob(sqlite3_stmt* stmt, int32_t idx, moonbit_bytes_t blob) {
+int32_t sqlite_bind_blob(void *obj, int32_t idx, moonbit_bytes_t blob) {
     int32_t len = Moonbit_array_length(blob);
-    return sqlite3_bind_blob(stmt, idx, blob, len, SQLITE_TRANSIENT);
+    return sqlite3_bind_blob(get_stmt(obj), idx, blob, len, SQLITE_TRANSIENT);
 }
 
 // Additional column getter functions
-int64_t sqlite_column_int64(sqlite3_stmt* stmt, int32_t col) {
-    return sqlite3_column_int64(stmt, col);
+int64_t sqlite_column_int64(void *obj, int32_t col) {
+    return sqlite3_column_int64(get_stmt(obj), col);
 }
 
 // Return SQLite BLOB column as MoonBit Bytes
-moonbit_bytes_t sqlite_column_blob(sqlite3_stmt* stmt, int32_t col) {
-    const void* blob = sqlite3_column_blob(stmt, col);
+moonbit_bytes_t sqlite_column_blob(void *obj, int32_t col) {
+    sqlite3_stmt *stmt = get_stmt(obj);
+    const void *blob = sqlite3_column_blob(stmt, col);
     int len = sqlite3_column_bytes(stmt, col);
     if (blob == NULL || len == 0) {
         return moonbit_make_bytes(0, 0);
@@ -182,75 +200,73 @@ moonbit_bytes_t sqlite_column_blob(sqlite3_stmt* stmt, int32_t col) {
     return result;
 }
 
-int32_t sqlite_column_bytes(sqlite3_stmt* stmt, int32_t col) {
-    return sqlite3_column_bytes(stmt, col);
+int32_t sqlite_column_bytes(void *obj, int32_t col) {
+    return sqlite3_column_bytes(get_stmt(obj), col);
 }
 
-int32_t sqlite_column_type(sqlite3_stmt* stmt, int32_t col) {
-    return sqlite3_column_type(stmt, col);
+int32_t sqlite_column_type(void *obj, int32_t col) {
+    return sqlite3_column_type(get_stmt(obj), col);
 }
 
 // Metadata functions
-int32_t sqlite_column_count(sqlite3_stmt* stmt) {
-    return sqlite3_column_count(stmt);
+int32_t sqlite_column_count(void *obj) {
+    return sqlite3_column_count(get_stmt(obj));
 }
 
-const char* sqlite_column_name(sqlite3_stmt* stmt, int32_t col) {
-    return sqlite3_column_name(stmt, col);
+const char *sqlite_column_name(void *obj, int32_t col) {
+    return sqlite3_column_name(get_stmt(obj), col);
 }
 
-int32_t sqlite_changes(sqlite3* db) {
-    return sqlite3_changes(db);
-}
+int32_t sqlite_changes(void *obj) { return sqlite3_changes(get_db(obj)); }
 
-int64_t sqlite_last_insert_rowid(sqlite3* db) {
-    return sqlite3_last_insert_rowid(db);
+int64_t sqlite_last_insert_rowid(void *obj) {
+    return sqlite3_last_insert_rowid(get_db(obj));
 }
 
 // Clear statement bindings
-int32_t sqlite_clear_bindings(sqlite3_stmt* stmt) {
-    return sqlite3_clear_bindings(stmt);
+int32_t sqlite_clear_bindings(void *obj) {
+    return sqlite3_clear_bindings(get_stmt(obj));
 }
 
 // Concurrency control
-int32_t sqlite_busy_timeout(sqlite3* db, int32_t ms) {
-    return sqlite3_busy_timeout(db, ms);
+int32_t sqlite_busy_timeout(void *obj, int32_t ms) {
+    return sqlite3_busy_timeout(get_db(obj), ms);
 }
 
 // Transaction management
-int32_t sqlite_get_autocommit(sqlite3* db) {
-    return sqlite3_get_autocommit(db);
+int32_t sqlite_get_autocommit(void *obj) {
+    return sqlite3_get_autocommit(get_db(obj));
 }
 
-int32_t sqlite_total_changes(sqlite3* db) {
-    return sqlite3_total_changes(db);
+int32_t sqlite_total_changes(void *obj) {
+    return sqlite3_total_changes(get_db(obj));
 }
 
 // Statement introspection
-const char* sqlite_sql(sqlite3_stmt* stmt) {
-    const char* sql = sqlite3_sql(stmt);
+const char *sqlite_sql(void *obj) {
+    const char *sql = sqlite3_sql(get_stmt(obj));
     return sql ? sql : "";
 }
 
-int32_t sqlite_bind_parameter_count(sqlite3_stmt* stmt) {
-    return sqlite3_bind_parameter_count(stmt);
+int32_t sqlite_bind_parameter_count(void *obj) {
+    return sqlite3_bind_parameter_count(get_stmt(obj));
 }
 
-int32_t sqlite_stmt_readonly(sqlite3_stmt* stmt) {
-    return sqlite3_stmt_readonly(stmt);
+int32_t sqlite_stmt_readonly(void *obj) {
+    return sqlite3_stmt_readonly(get_stmt(obj));
 }
 
 // Extended error handling
-int32_t sqlite_extended_errcode(sqlite3* db) {
-    return sqlite3_extended_errcode(db);
+int32_t sqlite_extended_errcode(void *obj) {
+    return sqlite3_extended_errcode(get_db(obj));
 }
 
 // Copy error string to global buffer (static storage)
 // Note: sqlite3_errstr returns static string, so we copy it
 static char errstr_buffer[256];
 
-const char* sqlite_errstr(int32_t errcode) {
-    const char* msg = sqlite3_errstr(errcode);
+const char *sqlite_errstr(int32_t errcode) {
+    const char *msg = sqlite3_errstr(errcode);
     if (msg) {
         strncpy(errstr_buffer, msg, sizeof(errstr_buffer) - 1);
         errstr_buffer[sizeof(errstr_buffer) - 1] = '\0';
@@ -262,8 +278,8 @@ const char* sqlite_errstr(int32_t errcode) {
 // Get parameter name (copy static string to buffer)
 static char param_name_buffer[256];
 
-const char* sqlite_bind_parameter_name(sqlite3_stmt* stmt, int32_t idx) {
-    const char* name = sqlite3_bind_parameter_name(stmt, idx);
+const char *sqlite_bind_parameter_name(void *obj, int32_t idx) {
+    const char *name = sqlite3_bind_parameter_name(get_stmt(obj), idx);
     if (name) {
         strncpy(param_name_buffer, name, sizeof(param_name_buffer) - 1);
         param_name_buffer[sizeof(param_name_buffer) - 1] = '\0';
@@ -272,9 +288,9 @@ const char* sqlite_bind_parameter_name(sqlite3_stmt* stmt, int32_t idx) {
     return "";
 }
 
-int32_t sqlite_bind_parameter_index(sqlite3_stmt* stmt, moonbit_bytes_t name) {
-    char* name_str = bytes_to_cstring(name);
-    int idx = sqlite3_bind_parameter_index(stmt, name_str);
+int32_t sqlite_bind_parameter_index(void *obj, moonbit_bytes_t name) {
+    char *name_str = bytes_to_cstring(name);
+    int idx = sqlite3_bind_parameter_index(get_stmt(obj), name_str);
     free(name_str);
     return idx;
 }
@@ -282,9 +298,9 @@ int32_t sqlite_bind_parameter_index(sqlite3_stmt* stmt, moonbit_bytes_t name) {
 // Get database filename (copy static string to buffer)
 static char db_filename_buffer[512];
 
-const char* sqlite_db_filename(sqlite3* db, moonbit_bytes_t dbname) {
-    char* dbname_str = bytes_to_cstring(dbname);
-    const char* filename = sqlite3_db_filename(db, dbname_str);
+const char *sqlite_db_filename(void *obj, moonbit_bytes_t dbname) {
+    char *dbname_str = bytes_to_cstring(dbname);
+    const char *filename = sqlite3_db_filename(get_db(obj), dbname_str);
     free(dbname_str);
 
     if (filename) {
@@ -295,9 +311,9 @@ const char* sqlite_db_filename(sqlite3* db, moonbit_bytes_t dbname) {
     return "";
 }
 
-int32_t sqlite_db_readonly(sqlite3* db, moonbit_bytes_t dbname) {
-    char* dbname_str = bytes_to_cstring(dbname);
-    int readonly = sqlite3_db_readonly(db, dbname_str);
+int32_t sqlite_db_readonly(void *obj, moonbit_bytes_t dbname) {
+    char *dbname_str = bytes_to_cstring(dbname);
+    int readonly = sqlite3_db_readonly(get_db(obj), dbname_str);
     free(dbname_str);
     return readonly;
 }
@@ -305,23 +321,23 @@ int32_t sqlite_db_readonly(sqlite3* db, moonbit_bytes_t dbname) {
 // Get expanded SQL (dynamically allocated string)
 static char expanded_sql_buffer[1024];
 
-const char* sqlite_expanded_sql(sqlite3_stmt* stmt) {
-    char* sql = sqlite3_expanded_sql(stmt);
+const char *sqlite_expanded_sql(void *obj) {
+    char *sql = sqlite3_expanded_sql(get_stmt(obj));
     if (sql) {
         strncpy(expanded_sql_buffer, sql, sizeof(expanded_sql_buffer) - 1);
         expanded_sql_buffer[sizeof(expanded_sql_buffer) - 1] = '\0';
-        sqlite3_free(sql);  // Important: free dynamically allocated string
+        sqlite3_free(sql); // Important: free dynamically allocated string
         return expanded_sql_buffer;
     }
     return "";
 }
 
 // Interrupt running query
-void sqlite_interrupt(sqlite3* db) {
-    sqlite3_interrupt(db);
+void sqlite_interrupt(void *obj) {
+    sqlite3_interrupt(get_db(obj));
 }
 
 // Set/get resource limits
-int32_t sqlite_limit(sqlite3* db, int32_t id, int32_t newVal) {
-    return sqlite3_limit(db, id, newVal);
+int32_t sqlite_limit(void *obj, int32_t id, int32_t newVal) {
+    return sqlite3_limit(get_db(obj), id, newVal);
 }


### PR DESCRIPTION
This PR fixes an issue that caused the native-target tests to be flaky on Linux.
I can't guarantee it completely eliminates the problem, but all tests now pass. Actually, I don't know why the macOS tests were unaffected.

### Root problem

`stub.c` returned raw `sqlite3*` and `sqlite3_stmt*` pointers to MoonBit. The native backend treats pointer fields as reference-counted MoonBit objects (`ptr_field_count=1`). During `Database`/`Statement` deallocation, `moonbit_decref()` was called on the raw SQLite pointer. It attempted to read 8 bytes before an expected object header (which didn't exist), silently corrupting mimalloc's heap metadata.

### Fix

All SQLite handles are now wrapped in `moonbit_make_external_object()` so MoonBit's reference-counting operates on valid memory. Stub functions now accept `void*` and obtain the real pointer via the `get_db()` and `get_stmt()` helpers, which were introduced by this PR.
